### PR TITLE
Update index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,3 +1,3 @@
-# No
+# Yes
 
 [Submit a pull request](https://github.com/mdwelsh/issamaltmanceoofopenai)


### PR DESCRIPTION
Update per latest news

Sam Altman Reinstated as OpenAI’s Chief Executive https://www.nytimes.com/2023/11/22/technology/openai-sam-altman-returns.html?smid=nytcore-android-share